### PR TITLE
Ignore errors when reading crontab listing as it fails if currently empty

### DIFF
--- a/advanced/Scripts/webpage.sh
+++ b/advanced/Scripts/webpage.sh
@@ -514,7 +514,7 @@ SpeedtestMode(){
 SetCronTab()
 {
   # Remove OLD
-  crontab -l > crontab.tmp
+  crontab -l > crontab.tmp || true
 
   if [[ "$1" == "0" ]]; then
       sed -i '/speedtest/d' crontab.tmp


### PR DESCRIPTION
On my stock raspberry pi with only pi-hole installed, I couldn't get SpeedTest to run. Turns out `crontab -l` would fail with a `no crontab for user` error.

This PR ignores the error of `crontab -l`, thus generating an empty file when it errors out, which can be amended and committed with `crontab -e` later on. As the later error is not hidden, if the error was a legitimate issue from `crontab`, it will be shown again when trying to edit the listing.